### PR TITLE
fix: Suppress body className hydration warning

### DIFF
--- a/src/pages/layout.tsx
+++ b/src/pages/layout.tsx
@@ -18,6 +18,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <html lang="en">
       <body
         className={`${inter.className} bg-slate-50 dark:bg-slate-900 text-slate-800 dark:text-slate-100 antialiased transition-colors duration-300`}
+        suppressHydrationWarning={true}
       >
         {children}
       </body>


### PR DESCRIPTION
Adds `suppressHydrationWarning={true}` to the <body> tag in `src/pages/layout.tsx`.

This is to address the hydration mismatch error specifically for the body's className, which can occur due to client-side theme application logic modifying classes after server render.

This change, combined with the previous fix for Hero component's random values, aims to stabilize hydration and allow theme styles to apply correctly.